### PR TITLE
Fix to take_two reference passing

### DIFF
--- a/play_game.py
+++ b/play_game.py
@@ -60,7 +60,7 @@ class AttackCard(KittenCard):
         super().__init__(name, selfcast=True, targetable=True)
     def effect(self, player: BasePlayer, target: BasePlayer):
         player.skip()
-        target.take_turn_twice()
+        target.take_turn_twice(self)
 
 class SeeTheFuture(KittenCard):
     def __init__(self, deck: pyCardDeck.Deck, name: str = "See The Future"):

--- a/player.py
+++ b/player.py
@@ -24,9 +24,9 @@ class Player(BasePlayer):
     def skip(self):
         pass
 
-    def take_turn_twice(self):
-        self.turn()
-        self.turn()
+    def take_turn_twice(self, game):
+        self.turn(game)
+        self.turn(game)
 
     def nope_prompt(self) -> bool:
         for card in self.hand:


### PR DESCRIPTION
As mentioned in the session, the change to pass the game object to the player's turn requires the same change to be reflected in the call to the take_turn_twice method.